### PR TITLE
Fixed: `Date` Display in Payment History Card on Profile Page

### DIFF
--- a/src/4_entities/me/ui/PaymentsCard/PaymentsCard.tsx
+++ b/src/4_entities/me/ui/PaymentsCard/PaymentsCard.tsx
@@ -26,7 +26,7 @@ const PaymentCard: FC<LightningTransactionSchema> = (props) => {
                                 : null
                         }
                     </Flex>
-                    <Typography className="opacity50">{getStringDate(new Date(props.time))}</Typography>
+                    <Typography className="opacity50">{getStringDate(new Date(props.time * 1000))}</Typography>
                 </Flex>
                 <Typography style={{ fontStyle: "italic" }}>"{props.memo}"</Typography>
             </Flex>

--- a/src/5_shared/utils/getStringDate.ts
+++ b/src/5_shared/utils/getStringDate.ts
@@ -6,6 +6,9 @@ const getStringDate = (date: Date) => {
     return monthNames[date.getMonth()] + ' '
         + date.getDate()
         + ', '
+        + date.getFullYear()
+        + ', '
+        + ' '
         + date.getHours().toString().padStart(2, "0")
         + ':' + date.getMinutes().toString().padStart(2, "0")
 }


### PR DESCRIPTION
### Problem:
- The dates on the payment history are being displayed incorrectly on the profile page. The current format does not properly handle the data returned from the `/api/history` endpoint.

## Issue ticket number and link:
- **Ticket Number:** [ 9 ]
- **Link:** [ https://github.com/Lightning-Bounties/lb-next/issues/9 ]

### closes: #9

### Evidence:

![image](https://github.com/user-attachments/assets/3b1fca40-060a-45dc-862f-83491146fb79)

### Acceptance Criteria
- [x] Correct date format is displayed in the Payment History card.
- [x] Dates align with data from the /api/history endpoint.
- [x] Tested for accuracy with valid and edge-case data.