### PR TITLE
Fixed(Header): Fixed Mobile Styling After `Login View`

### DIFF
--- a/src/2_widgets/header/headerBox/ui/Header.module.css
+++ b/src/2_widgets/header/headerBox/ui/Header.module.css
@@ -11,4 +11,8 @@
     .themeToggler {
         margin-left: 8px !important;
     }
+
+    .mobileGap {
+        gap: 5px !important;
+    }
 }

--- a/src/2_widgets/header/headerBox/ui/Header.tsx
+++ b/src/2_widgets/header/headerBox/ui/Header.tsx
@@ -44,7 +44,7 @@ const Header: FC<HeaderProps> = ({ profileSlot, walletSlot }) => {
                         <Link href="https://www.lightningbounties.com/" target="_blank" rel="noopener noreferrer">About</Link>
                     </Flex>
                 </Flex>
-                <Flex gap="middle" align="center">
+                <Flex gap="middle" align="center" className={s.mobileGap}>
                     <Flex className={s.themeToggler}>
                     <ThemeToggler />
                     </Flex>

--- a/src/3_features/me/headerAuth/ui/HeaderAuth.module.css
+++ b/src/3_features/me/headerAuth/ui/HeaderAuth.module.css
@@ -10,5 +10,6 @@
     }
     .textSize {
         font-size: 12px !important;
+        margin-left: 25px !important;
     }
 }

--- a/src/5_shared/ui/Avatar/Avatar.module.css
+++ b/src/5_shared/ui/Avatar/Avatar.module.css
@@ -63,3 +63,10 @@
     color: var(--ant-text-color);
     font-size: 24px;
 }
+
+@media screen and (max-width: 600px) {
+    .box {
+        width: 30px;
+        height: 30px;
+    }
+}

--- a/src/5_shared/ui/Price/Price.module.css
+++ b/src/5_shared/ui/Price/Price.module.css
@@ -1,3 +1,10 @@
 body .value {
     font-size: 18px;
 }
+
+@media screen and (max-width: 600px) {
+    body .value {
+        font-size: 14px; 
+        white-space: nowrap;
+    }
+}


### PR DESCRIPTION
### Problem:
- After login, the `sats` amount overflows the header.
- The `Logout` button also overflows the header.

## Issue ticket number and link:
- **Ticket Number:** [ 17 ]
- **Link:** [ https://github.com/Lightning-Bounties/lb-next/issues/17 ]

### closes #17

### Evidence:

https://www.loom.com/share/e1ae746408024e8e97e586a6ed18f086

![image](https://github.com/user-attachments/assets/6ba15994-b407-4682-a5dc-50da6af73a53)

![image](https://github.com/user-attachments/assets/9f6c7570-80ea-40f7-8794-b059a1616438)

### Acceptance Criteria:
- [x] The sats amount is properly contained within the header on mobile devices.
- [x] The Logout button is correctly aligned and does not overflow the header.
- [x] No styling issues on various screen sizes after login.