### PR TITLE
Fixed `QR Code Card` Display and Overflow in Profile > Deposit Section

### DIFF
--- a/src/3_features/me/profileDeposit/ui/ProfileDeposit.module.css
+++ b/src/3_features/me/profileDeposit/ui/ProfileDeposit.module.css
@@ -2,8 +2,13 @@
     width: 220px;
     height: 220px;
     box-sizing: border-box;
+    border-radius: 10px; 
+    overflow: hidden;
 }
 
 .qrBox :global(.ant-card-body) {
-    padding: 10px !important;
+    padding: 0px !important;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }

--- a/src/3_features/me/profileDeposit/ui/ProfileDeposit.tsx
+++ b/src/3_features/me/profileDeposit/ui/ProfileDeposit.tsx
@@ -68,116 +68,101 @@ const ProfileDeposit: FC = () => {
         },
     ]
 
-    return (
-        <>
-            {contextHolder}
-            <Tour open={open} onClose={() => setOpen(false)} steps={steps} />
-            <Row gutter={[12, 12]} align="middle">
-                <Col span={10} md={10} xs={24} sm={12}>
-                    <Form
-                        onFinish={onFinishHandler}
-                    >
-                        <Flex vertical gap="small">
-                            <Flex gap="small" align="start">
-                                <Typography style={{ flexShrink: 0, marginTop: '5px' }}>Amount:</Typography>
-                                <Form.Item
-                                    name="amount_sats"
-                                    rules={[
-                                        {
-                                            required: true,
-                                            message: 'Amount Required - how many sats do you want to deposit?'
-                                        },
-                                        {
-                                            validator: (_, value) => {
-                                              if (!value || value <= 100000) {
+return (
+    <>
+        {contextHolder}
+        <Tour open={open} onClose={() => setOpen(false)} steps={steps} />
+        <Row gutter={[12, 12]} align="middle">
+            <Col span={10} md={10} xs={24} sm={12}>
+                <Form onFinish={onFinishHandler}>
+                    <Flex vertical gap="small">
+                        <Flex gap="small" align="start">
+                            <Typography style={{ flexShrink: 0, marginTop: '5px' }}>Amount:</Typography>
+                            <Form.Item
+                                name="amount_sats"
+                                rules={[
+                                    {
+                                        required: true,
+                                        message: 'Amount Required - how many sats do you want to deposit?'
+                                    },
+                                    {
+                                        validator: (_, value) => {
+                                            if (!value || value <= 100000) {
                                                 return Promise.resolve();
-                                              }
-                                              return Promise.reject(new Error('Amount too high; max allowed: 100,000'));
                                             }
-                                          }
-                                    ]}
-                                >
-                                    <Input placeholder='1,000' />
-                                </Form.Item>
-                            </Flex>
-                            <Flex gap="large" align="start">
-                                <Typography className="opacity50">max allowed: 100,000</Typography>
-                                <QuestionCircleOutlined
-                                        style={{ flexShrink: 0, marginTop: '4px' }}
-                                        ref={ref1}
-                                        onClick={() => { setOpen(true) }}
-                                        className={`opacity50 ${s.question}`}
-                                    />
-                            </Flex>
-                            <Button loading={isPending} htmlType="submit" type="primary" style={{ marginTop: '20px' }}>Generate</Button>
+                                            return Promise.reject(new Error('Amount too high; max allowed: 100,000'));
+                                        }
+                                    }
+                                ]}
+                            >
+                                <Input placeholder='1,000' />
+                            </Form.Item>
                         </Flex>
-                    </Form>
-                    {
-                        invoiceInfo
-                            ? <ProfileDepositStatus checkingId={invoiceInfo.checkingId} />
-                            : <></>
-                    }
-                </Col>
-                <Col span={14} md={14} xs={24} sm={12}>
-                    <Flex vertical align="center" gap="small">
-                        {
-                            invoiceInfo
-                                ? <>
-                                    <Typography style={{ flexShrink: 0, marginTop: '5px' }}>Deposit: {invoiceInfo.amount} sats</Typography> 
-                                    <Typography className="opacity50" style={{ textAlign: 'center' }}>BOLT-11 Invoice: scan with any lightning wallet
-                                        &nbsp;
-                                        <QuestionCircleOutlined
-                                            style={{ flexShrink: 0, marginTop: '8px' }}
-                                            ref={ref2}
-                                            onClick={() => { setOpen(true) }}
-                                            className={`opacity50 ${s.question}`}
-                                        />
-                                    </Typography>
-                                </>
-                                : null
-                        }
-                        <Card className={s.qrBox} style={qrExpandedMode ? {width:'350px', height: '350px'} : {width:'220px', height: '220px'}}>
-                            {invoiceInfo && 
-                                <Tooltip placement="top" title={qrExpandedMode ? "Click to reset size": "Click to enlarge"}>
-                                    <QRCodeCanvas 
-                                        size={qrExpandedMode ? 350 : 220} 
-                                        value={`lightning:${invoiceInfo.invoice}`} 
-                                        includeMargin={true}
-                                        onClick={() => setQrExpandedMode(!qrExpandedMode) }
-                                        style={{ cursor: 'pointer' }}
-                                    />
-                                </Tooltip>
-                            }
-                        </Card>
-                        {
-                            invoiceInfo
-                                ? <Flex align="center" gap="small" className="opacity50" style={{marginTop: '20px'}}>
-                                    <Tooltip title="Copy Invoice to Clipboard">
-                                        <Button
-                                            onClick={() => {
-                                                navigator.clipboard.writeText(invoiceInfo.invoice)
-                                                setCopied(true)
-                                                setTimeout(() => {
-                                                    setCopied(false)
-                                                }, 2000)
-                                            }}
-                                            type="text"
-                                            size="small"
-                                            icon={copied ? <CheckOutlined /> : <CopyOutlined />}
-                                        >{copied ? 'Copied' : null}</Button>
-                                    </Tooltip>
-                                    <Popover content={<Typography style={{ width: '200px' }}>{invoiceInfo.invoice}</Typography>}>
-                                        <Typography style={{ border: '1px solid', padding: ' 5px' }}>
-                                            {invoiceInfo.invoice?.slice(0, 10)}...
-                                        </Typography>
-                                    </Popover>
-                                </Flex>
-                                : null
-                        }
+                        <Flex gap="large" align="start">
+                            <Typography className="opacity50">max allowed: 100,000</Typography>
+                            <QuestionCircleOutlined
+                                style={{ flexShrink: 0, marginTop: '4px' }}
+                                ref={ref1}
+                                onClick={() => { setOpen(true) }}
+                                className={`opacity50 ${s.question}`}
+                            />
+                        </Flex>
+                        <Button loading={isPending} htmlType="submit" type="primary" style={{ marginTop: '20px' }}>Generate</Button>
                     </Flex>
-                </Col>
-            </Row>
-        </>
-    )
+                </Form>
+                {invoiceInfo && <ProfileDepositStatus checkingId={invoiceInfo.checkingId} />}
+            </Col>
+            <Col span={14} md={14} xs={24} sm={12}>
+                {invoiceInfo && (
+                    <Flex vertical align="center" gap="small">
+                        <Typography style={{ flexShrink: 0, marginTop: '5px' }}>Deposit: {invoiceInfo.amount} sats</Typography>
+                        <Typography className="opacity50" style={{ textAlign: 'center' }}>
+                            BOLT-11 Invoice: scan with any lightning wallet
+                            &nbsp;
+                            <QuestionCircleOutlined
+                                style={{ flexShrink: 0, marginTop: '8px' }}
+                                ref={ref2}
+                                onClick={() => { setOpen(true) }}
+                                className={`opacity50 ${s.question}`}
+                            />
+                        </Typography>
+                        <Card className={s.qrBox} style={qrExpandedMode ? { width: '350px', height: '350px' } : { width: '220px', height: '220px' }}>
+                            <Tooltip placement="top" title={qrExpandedMode ? "Click to reset size" : "Click to enlarge"}>
+                                <QRCodeCanvas
+                                    size={qrExpandedMode ? 350 : 220}
+                                    value={`lightning:${invoiceInfo.invoice}`}
+                                    includeMargin={true}
+                                    onClick={() => setQrExpandedMode(!qrExpandedMode)}
+                                    style={{ cursor: 'pointer' }}
+                                />
+                            </Tooltip>
+                        </Card>
+                        <Flex align="center" gap="small" className="opacity50" style={{ marginTop: '20px' }}>
+                            <Tooltip title="Copy Invoice to Clipboard">
+                                <Button
+                                    onClick={() => {
+                                        navigator.clipboard.writeText(invoiceInfo.invoice)
+                                        setCopied(true)
+                                        setTimeout(() => {
+                                            setCopied(false)
+                                        }, 2000)
+                                    }}
+                                    type="text"
+                                    size="small"
+                                    icon={copied ? <CheckOutlined /> : <CopyOutlined />}
+                                >{copied ? 'Copied' : null}</Button>
+                            </Tooltip>
+                            <Popover content={<Typography style={{ width: '200px' }}>{invoiceInfo.invoice}</Typography>}>
+                                <Typography style={{ border: '1px solid', padding: ' 5px' }}>
+                                    {invoiceInfo.invoice?.slice(0, 10)}...
+                                </Typography>
+                            </Popover>
+                        </Flex>
+                    </Flex>
+                )}
+            </Col>
+        </Row>
+    </>
+)
 }
 export { ProfileDeposit }


### PR DESCRIPTION
### Problem:
- The `QR box` appears immediately without the need to click the `Generate` button.
- The `QR code` overflows from its container, both in `small and large` display sizes, affecting layout responsiveness.

## Issue ticket number and link:
- **Ticket Number:** [ 24 ]
- **Link:** [ https://github.com/Lightning-Bounties/lb-next/issues/24 ]

### closes #24

### Evidence:

![image](https://github.com/user-attachments/assets/2ee0f7e2-8882-46db-8e3d-3af9e7a3bbc8)

![image](https://github.com/user-attachments/assets/5888b03a-c72e-449e-aec8-0f0860d776bc)

![image](https://github.com/user-attachments/assets/0f03be2f-e46e-4279-bc93-5d5b2693e8a3)

https://www.loom.com/share/2febddea547140e19d8c206eb7ecd777

### Acceptance Criteria:
- [x] QR box is hidden by default and only appears after clicking the `Generate` button.
- [x] QR code fits properly within the box, ensuring responsiveness across different screen sizes.