### PR TITLE
Fix `Feed Card`: Incorrect Routing for `Rewarder Profiles`

### DIFF
--- a/src/4_entities/feed/ui/FeedCard/FeedCard.tsx
+++ b/src/4_entities/feed/ui/FeedCard/FeedCard.tsx
@@ -29,6 +29,26 @@ const FeedCard: FC<FeedCardProps> = (props) => {
         e.stopPropagation();
     };
 
+    const renderRewarderAvatars = () => {
+        const rewarders = [
+            props.last_rewarder_data,
+            props.second_last_rewarder_data,
+            props.third_last_rewarder_data
+        ];
+
+        return rewarders.map((rewarder, index) => (
+            rewarder && (
+                <Link
+                    key={index}
+                    href={'/' + appRoutes.profile + '/' + rewarder.id}
+                    onClick={handleLinkClick}
+                >
+                    <Avatar avatarUrl={rewarder.avatar_url as string} />
+                </Link>
+            )
+        ));
+    };
+
     return (
         <Card bordered={false}>
             <div className={s.card} onClick={handleCardClick}>
@@ -47,15 +67,7 @@ const FeedCard: FC<FeedCardProps> = (props) => {
                     <Col md={18} xs={14} sm={14} className={s.owner}>
                         <Flex vertical gap="small">
                             <Flex>
-                                <Link href={'/' + appRoutes.profile + '/' + props.last_rewarder_data?.id} onClick={handleLinkClick}>
-                                    <Avatar
-                                        withOthers={[
-                                            props.second_last_rewarder_data?.avatar_url ?? '',
-                                            props.third_last_rewarder_data?.avatar_url ?? ''
-                                        ]}
-                                        avatarUrl={props.last_rewarder_data?.avatar_url as string}
-                                    />
-                                </Link>
+                                {renderRewarderAvatars()}
                             </Flex>
                             <Flex align="center" gap="small">
                                 <Link href={appRoutes.profile + '/' + props.last_rewarder_data?.id} rel="nofollow" onClick={handleLinkClick}>


### PR DESCRIPTION
### Problem:
- When clicking on the `third Rewarder profile`, it redirects to the `first Rewarder profile`. Similarly, clicking on the `second Rewarder profile` redirects to the `first Rewarder profile`.
- `lb-founders logo` does not display consistently across all Feed cards.

## Issue ticket number and link:
- **Ticket Number:** [ 26 ]
- **Link:** [ https://github.com/Lightning-Bounties/lb-next/issues/26 ]

### closes #26

### Evidence:

https://www.loom.com/share/115353d38aa042f89451fec475997f1d

![image](https://github.com/user-attachments/assets/26da048e-4aec-462d-84a6-126ecc470487)

### Acceptance Criteria:
- [x] Clicking on a Rewarder profile should navigate to the correct profile page.
- [x] The routing should accurately match the selected profile, without redirecting to other profiles.
- [x] The `lb-founders` logo should appear consistently across all Feed cards.