### PR TITLE
Fixed [Payment History]:  Displays Same Cards for Both `Deposit` and `Withdraw` Actions

### DIFF
--- a/src/1_pages/me/ui/Me.tsx
+++ b/src/1_pages/me/ui/Me.tsx
@@ -32,7 +32,7 @@ const Me = () => {
                     <Flex vertical gap="middle">
                         <ProfileInfo
                             rewardsHistorySlot={<ProfileRewardsHistory />}
-                            paymentsHistorySlot={<ProfilePaymentsHistory />}
+                            paymentsHistorySlot={({ activeTab }) => <ProfilePaymentsHistory activeTab={activeTab} />}
                         />
                     </Flex>
                 </Col>

--- a/src/2_widgets/me/profileInfo/ui/ProfileInfo.tsx
+++ b/src/2_widgets/me/profileInfo/ui/ProfileInfo.tsx
@@ -11,8 +11,7 @@ import { FC, ReactNode, useState } from 'react'
 
 type ProfileInfoProps = {
     rewardsHistorySlot?: ReactNode,
-    paymentsHistorySlot?: ReactNode
-}
+    paymentsHistorySlot?: ((props: { activeTab?: 'deposit' | 'withdraw' }) => ReactNode)}
 
 const ProfileInfo: FC<ProfileInfoProps> = ({ rewardsHistorySlot, paymentsHistorySlot }) => {
 
@@ -94,7 +93,7 @@ const ProfileInfo: FC<ProfileInfoProps> = ({ rewardsHistorySlot, paymentsHistory
                     {
                         key: '2',
                         label: 'Payments History',
-                        children: paymentsHistorySlot
+                        children: paymentsHistorySlot?.({ activeTab })
                     }
                 ]}
             />

--- a/src/2_widgets/me/profilePaymentsHistory/ui/ProfilePaymentsHistory.tsx
+++ b/src/2_widgets/me/profilePaymentsHistory/ui/ProfilePaymentsHistory.tsx
@@ -4,12 +4,23 @@ import { FeedCard } from '@/4_entities/feed'
 import { PaymentCard, profileApi } from '@/4_entities/me'
 import { useQuery } from '@tanstack/react-query'
 import { Empty, Flex, Spin } from 'antd'
+import { FC } from 'react'
 
-const ProfilePaymentsHistory = () => {
+type ProfilePaymentsHistoryProps = {
+    activeTab?: 'deposit' | 'withdraw'
+}
 
+const ProfilePaymentsHistory: FC<ProfilePaymentsHistoryProps> = ({ activeTab }) => {
     const { data, isLoading } = useQuery({
         queryKey: profileApi.qkGetProfilePaymentsHistory(),
         queryFn: () => profileApi.getProfilePaymentsHistory()
+    })
+
+    const filteredData = data?.filter(item => {
+        if (!activeTab) return true
+        if (activeTab === 'deposit' && item.amount > 0) return true
+        if (activeTab === 'withdraw' && item.amount < 0) return true
+        return false
     })
 
     return (
@@ -17,8 +28,8 @@ const ProfilePaymentsHistory = () => {
             {
                 isLoading
                     ? <Spin />
-                    : data?.length
-                        ? data?.map(item => <PaymentCard key={item.time} {...item} />)
+                    : filteredData?.length
+                        ? filteredData.map(item => <PaymentCard key={item.time} {...item} />)
                         : <Empty
                             image={Empty.PRESENTED_IMAGE_SIMPLE}
                             description="The list is empty"


### PR DESCRIPTION
### Problem:
- When I click the `Deposit` or `Withdraw` button, the same `Payment History Cards` are displayed for both actions. 

## Issue ticket number and link:
- **Ticket Number:** [ 28 ]
- **Link:** [ https://github.com/Lightning-Bounties/lb-next/issues/28]

### closes #28

### Evidence:

- `Deposit`

![image](https://github.com/user-attachments/assets/a5cc03ad-cc7a-435b-99ad-4b6ab77675fe)

- `Withdraw`

![image](https://github.com/user-attachments/assets/c26c8e15-8f50-4726-99ea-d1a12c1f5b2f)

-  If no action is selected, display all Payment History:

![image](https://github.com/user-attachments/assets/a9dd18f7-5292-4d34-a3a9-99fe77a59b56)

https://www.loom.com/share/224e827bc9f24b77816b90e2ce583995

### Acceptance Criteria:
- [x] The Payment History section should correctly display the transaction history relevant to either `Deposit` or `Withdraw`, based on the action selected.
- [x] If no action is selected, display all Payment History.