### PR TITLE
[FIXED] Dropdown Menu Display Bug in Advanced Settings (Dark Mode Only)

### DIFF
--- a/src/5_shared/themes/dark.ts
+++ b/src/5_shared/themes/dark.ts
@@ -28,7 +28,11 @@ const darkTheme: ThemeConfig = {
         Breadcrumb: {
             linkColor: 'rgba(255,255,255,.5)',
             separatorColor: 'rgba(255,255,255,.5)'
-        }
+        },
+        Select: {
+            controlItemBgHover: "rgba(255,255,255,.5)",
+            controlItemBgActive: "rgb(89, 126, 247)",
+        },
     }
 }
 


### PR DESCRIPTION
My first lightning bounty!

I've fixed the background color so the text is now legible both when hovering and when selected.

<img width="902" alt="Screenshot 2025-01-29 at 12 38 19 AM" src="https://github.com/user-attachments/assets/435d47bc-f6fe-4935-b64c-fc95b939f831" />

close #55 