### PR TITLE
[FIXED] Balance updated on profile after successful withdraw

### DIFF
--- a/src/2_widgets/me/profileInfo/ui/ProfileInfo.tsx
+++ b/src/2_widgets/me/profileInfo/ui/ProfileInfo.tsx
@@ -19,13 +19,12 @@ const ProfileInfo: FC<ProfileInfoProps> = ({ rewardsHistorySlot, paymentsHistory
     const { data } = useQuery({
         queryKey: userApi.qkGetUserData(),
         queryFn: () => userApi.getUserData()
-    })
+    });
 
-    // TODO: wallet to separate component
-    const { data: userWallet } = useQuery({
+    const { data: userWallet, refetch } = useQuery({
         queryKey: profileApi.qkGetUserWallet(),
         queryFn: () => profileApi.getUserWallet()
-    })
+    });
 
     const [activeTab, setActiveTab] = useState<'deposit' | 'withdraw' | undefined>(undefined)
 
@@ -76,7 +75,7 @@ const ProfileInfo: FC<ProfileInfoProps> = ({ rewardsHistorySlot, paymentsHistory
                         {
                             activeTab === 'deposit'
                                 ? <ProfileDeposit />
-                                : <ProfileWithdraw />
+                                : <ProfileWithdraw refetch={refetch} />
                         }
                         <Divider />
                     </>
@@ -99,6 +98,7 @@ const ProfileInfo: FC<ProfileInfoProps> = ({ rewardsHistorySlot, paymentsHistory
                 ]}
             />
         </Flex>
-    )
+    );
 }
+
 export { ProfileInfo }


### PR DESCRIPTION
A refetch prop was added to the ProfileWithdraw component to refresh the wallet balance after funds are withdrawn.

Also (1) renamed "Create" button to "Withdraw" to match the information bubble 

<img width="471" alt="Screenshot 2025-02-02 at 11 56 04 PM" src="https://github.com/user-attachments/assets/bdc615dc-878f-43ce-821f-b4ab9a44198c" />

and (2) disabled the withdraw button until something is entered in the invoice field

<img width="369" alt="Screenshot 2025-02-02 at 11 55 50 PM" src="https://github.com/user-attachments/assets/37d26ef2-7cff-4880-baaa-7b7d40171374" />

close #31 
