### PR TITLE
Add Followers tab to Audience page

### DIFF
--- a/src/1_pages/profile/ui/Profile.tsx
+++ b/src/1_pages/profile/ui/Profile.tsx
@@ -1,7 +1,7 @@
 import { Button, Col, Flex, Row, Tabs } from 'antd';
 import s from './Profile.module.css';
 import Link from 'next/link';
-import Title from 'antd/es/typography/Title';
+import { Title, Typography } from 'antd/es/typography';
 import { ProfileRewardCard } from '@/4_entities/me';
 import { ProfileBountyCard } from '@/4_entities/me';
 import { FC } from 'react';
@@ -12,6 +12,8 @@ import {
     UserSchema,
 } from '@/5_shared/gen';
 import { ProfileEmptyRewardsList } from './ProfileEmptyRewardsList';
+import { useQuery } from '@tanstack/react-query';
+import { userApi } from '@4_entities/user';
 
 type ProfileProps = {
     userInfo: UserSchema;

--- a/src/4_entities/user/api/user.api.ts
+++ b/src/4_entities/user/api/user.api.ts
@@ -96,3 +96,12 @@ class UserApi {
 const userApi = new UserApi();
 
 export { userApi };
+
+    qkGetFollowers() {
+        return [this.UserApiKey, 'getFollowers'];
+    }
+
+    async getFollowers() {
+        const resp = await appApi.users.getUserFollowersApiUsersFollowersGet();
+        return resp;
+    }


### PR DESCRIPTION
Implements Followers tab in user profile page showing list of followers with avatars and usernames. Includes API call to fetch followers data.

close #82