### PR TITLE
feat: show existing GitHub PRs on issue page (closes #76)

### DIFF
--- a/src/2_widgets/issue/issueBaseInfo/ui/IssueBaseInfo.tsx
+++ b/src/2_widgets/issue/issueBaseInfo/ui/IssueBaseInfo.tsx
@@ -15,7 +15,10 @@ import { orange, grey } from '@ant-design/colors';
 import { IssueBaseInfoAddReward } from './IssueBaseInfoAddReward';
 import { IssueExistingPulls } from './IssueExistingPulls';
 import { Prices } from '@/3_features/me/prices';
-import { fetchLinkedPullRequests } from '@/5_shared/utils/githubLinkedPulls';
+import {
+    countOpenLinkedPulls,
+    fetchLinkedPullRequests,
+} from '@/5_shared/utils/githubLinkedPulls';
 
 const IssueBaseInfoDesc = dynamic(() => import('./IssueBaseInfoDesc'), {
     ssr: false,
@@ -32,7 +35,7 @@ const IssueBaseInfo: FC<IssueBaseInfoProps> = async ({ rewardId }) => {
             data.repository_data.full_name,
             data.issue_number,
         );
-        const openPullCount = linkedPulls.filter((p) => p.state === 'open').length;
+        const openPullCount = countOpenLinkedPulls(linkedPulls);
 
         return (
             <Flex vertical gap="large">

--- a/src/2_widgets/issue/issueBaseInfo/ui/IssueBaseInfo.tsx
+++ b/src/2_widgets/issue/issueBaseInfo/ui/IssueBaseInfo.tsx
@@ -13,7 +13,9 @@ import { appRoutes } from '@/5_shared/config/appRoutes';
 import { IssueBaseInfoCheckPull } from './IssueBaseInfoCheckPull';
 import { orange, grey } from '@ant-design/colors';
 import { IssueBaseInfoAddReward } from './IssueBaseInfoAddReward';
+import { IssueExistingPulls } from './IssueExistingPulls';
 import { Prices } from '@/3_features/me/prices';
+import { fetchLinkedPullRequests } from '@/5_shared/utils/githubLinkedPulls';
 
 const IssueBaseInfoDesc = dynamic(() => import('./IssueBaseInfoDesc'), {
     ssr: false,
@@ -26,6 +28,11 @@ type IssueBaseInfoProps = {
 const IssueBaseInfo: FC<IssueBaseInfoProps> = async ({ rewardId }) => {
     try {
         const data = await issueApi.getIssueData(rewardId);
+        const linkedPulls = await fetchLinkedPullRequests(
+            data.repository_data.full_name,
+            data.issue_number,
+        );
+        const openPullCount = linkedPulls.filter((p) => p.state === 'open').length;
 
         return (
             <Flex vertical gap="large">
@@ -62,6 +69,23 @@ const IssueBaseInfo: FC<IssueBaseInfoProps> = async ({ rewardId }) => {
                             }}
                         >
                             Closed
+                        </Typography>
+                    )}
+                    {openPullCount > 0 && (
+                        <Typography
+                            style={{
+                                display: 'inline-block',
+                                color: '#1677ff',
+                                padding: '3px 10px',
+                                borderRadius: '4px',
+                                fontWeight: 'bold',
+                                marginLeft: '10px',
+                                textAlign: 'center',
+                                border: '1px solid #91caff',
+                            }}
+                        >
+                            {openPullCount} open PR
+                            {openPullCount === 1 ? '' : 's'}
                         </Typography>
                     )}
                     &nbsp; &nbsp; &nbsp; &nbsp;
@@ -113,6 +137,7 @@ const IssueBaseInfo: FC<IssueBaseInfoProps> = async ({ rewardId }) => {
                         </Typography>
                     </Flex>
                 </Flex>
+                <IssueExistingPulls pulls={linkedPulls} />
                 {data.winner_data && (
                     <Flex
                         className={s.info__line}

--- a/src/2_widgets/issue/issueBaseInfo/ui/IssueExistingPulls.tsx
+++ b/src/2_widgets/issue/issueBaseInfo/ui/IssueExistingPulls.tsx
@@ -1,0 +1,49 @@
+import { Flex, Tag, Typography } from 'antd';
+import Link from 'next/link';
+import { FC } from 'react';
+import { LinkedPullRequest } from '@/5_shared/utils/githubLinkedPulls';
+
+type Props = {
+    pulls: LinkedPullRequest[];
+};
+
+/**
+ * Lists GitHub PRs that reference this bounty issue (LB issue page).
+ */
+const IssueExistingPulls: FC<Props> = ({ pulls }) => {
+    if (!pulls.length) return null;
+
+    const openCount = pulls.filter((p) => p.state === 'open').length;
+
+    return (
+        <Flex vertical gap="small">
+            <Flex align="center" gap="small">
+                <Typography className="opacity50">Existing PRs</Typography>
+                <Tag color={openCount ? 'blue' : 'default'}>
+                    {openCount ? `${openCount} open` : `${pulls.length} closed`}
+                </Tag>
+            </Flex>
+            <Flex vertical gap={6}>
+                {pulls.map((pr) => (
+                    <Flex key={pr.number} align="center" gap="small" wrap="wrap">
+                        <Tag color={pr.state === 'open' ? 'processing' : 'default'}>
+                            {pr.draft ? 'draft' : pr.state}
+                        </Tag>
+                        <Link
+                            href={pr.html_url}
+                            target="_blank"
+                            rel="nofollow noreferrer"
+                        >
+                            #{pr.number} {pr.title}
+                        </Link>
+                        <Typography className="opacity50">
+                            @{pr.user_login}
+                        </Typography>
+                    </Flex>
+                ))}
+            </Flex>
+        </Flex>
+    );
+};
+
+export { IssueExistingPulls };

--- a/src/2_widgets/issue/issueBaseInfo/ui/IssueExistingPulls.tsx
+++ b/src/2_widgets/issue/issueBaseInfo/ui/IssueExistingPulls.tsx
@@ -1,7 +1,10 @@
 import { Flex, Tag, Typography } from 'antd';
 import Link from 'next/link';
 import { FC } from 'react';
-import { LinkedPullRequest } from '@/5_shared/utils/githubLinkedPulls';
+import {
+    countOpenLinkedPulls,
+    type LinkedPullRequest,
+} from '@/5_shared/utils/githubLinkedPulls';
 
 type Props = {
     pulls: LinkedPullRequest[];
@@ -13,7 +16,7 @@ type Props = {
 const IssueExistingPulls: FC<Props> = ({ pulls }) => {
     if (!pulls.length) return null;
 
-    const openCount = pulls.filter((p) => p.state === 'open').length;
+    const openCount = countOpenLinkedPulls(pulls);
 
     return (
         <Flex vertical gap="small">

--- a/src/2_widgets/issue/issueBaseInfo/ui/IssueExistingPulls.tsx
+++ b/src/2_widgets/issue/issueBaseInfo/ui/IssueExistingPulls.tsx
@@ -10,6 +10,11 @@ type Props = {
     pulls: LinkedPullRequest[];
 };
 
+function stateLabel(pr: LinkedPullRequest): string {
+    if (pr.draft && pr.state === 'open') return 'draft';
+    return pr.state;
+}
+
 /**
  * Lists GitHub PRs that reference this bounty issue (LB issue page).
  */
@@ -28,9 +33,18 @@ const IssueExistingPulls: FC<Props> = ({ pulls }) => {
             </Flex>
             <Flex vertical gap={6}>
                 {pulls.map((pr) => (
-                    <Flex key={pr.number} align="center" gap="small" wrap="wrap">
-                        <Tag color={pr.state === 'open' ? 'processing' : 'default'}>
-                            {pr.draft ? 'draft' : pr.state}
+                    <Flex
+                        key={pr.html_url || pr.number}
+                        align="center"
+                        gap="small"
+                        wrap="wrap"
+                    >
+                        <Tag
+                            color={
+                                pr.state === 'open' ? 'processing' : 'default'
+                            }
+                        >
+                            {stateLabel(pr)}
                         </Tag>
                         <Link
                             href={pr.html_url}

--- a/src/4_entities/feed/ui/FeedCard/FeedCard.tsx
+++ b/src/4_entities/feed/ui/FeedCard/FeedCard.tsx
@@ -12,6 +12,7 @@ import { appRoutes } from '@/5_shared/config/appRoutes';
 import { orange } from '@ant-design/colors';
 import { useRouter } from 'next/navigation';
 import { Prices } from '@/3_features/me/prices';
+import { OpenPrBadge } from './OpenPrBadge';
 
 type FeedCardProps = IssueExpandedSchema & {
     guideSlot?: ReactNode;
@@ -63,7 +64,11 @@ const FeedCard: FC<FeedCardProps> = (props) => {
                     {props.repository_data.full_name}
                 </Link>
                 <Title level={3} className={s.title}>
-                    {props.title}
+                    {props.title}{' '}
+                    <OpenPrBadge
+                        fullName={props.repository_data.full_name}
+                        issueNumber={props.issue_number}
+                    />
                 </Title>
                 <Row gutter={[12, 12]} align="middle">
                     <Col md={18} xs={14} sm={14} className={s.owner}>

--- a/src/4_entities/feed/ui/FeedCard/OpenPrBadge.tsx
+++ b/src/4_entities/feed/ui/FeedCard/OpenPrBadge.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { Tag } from 'antd';
+import { FC, useEffect, useState } from 'react';
+
+type Props = {
+    fullName: string;
+    issueNumber: number;
+};
+
+/**
+ * Lightweight client badge: shows open PR count for a GitHub issue (issue #76).
+ */
+const OpenPrBadge: FC<Props> = ({ fullName, issueNumber }) => {
+    const [count, setCount] = useState<number | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        const q = encodeURIComponent(
+            `repo:${fullName} is:pr is:open ${issueNumber} in:title,body`,
+        );
+        fetch(`https://api.github.com/search/issues?q=${q}&per_page=5`, {
+            headers: { Accept: 'application/vnd.github+json' },
+        })
+            .then((r) => (r.ok ? r.json() : null))
+            .then((data) => {
+                if (cancelled || !data) return;
+                const n = Array.isArray(data.items) ? data.items.length : 0;
+                setCount(n);
+            })
+            .catch(() => {
+                if (!cancelled) setCount(null);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [fullName, issueNumber]);
+
+    if (!count) return null;
+    return (
+        <Tag color="blue" style={{ marginLeft: 8 }}>
+            {count} open PR{count === 1 ? '' : 's'}
+        </Tag>
+    );
+};
+
+export { OpenPrBadge };

--- a/src/4_entities/feed/ui/FeedCard/OpenPrBadge.tsx
+++ b/src/4_entities/feed/ui/FeedCard/OpenPrBadge.tsx
@@ -1,30 +1,75 @@
 'use client';
 import { Tag } from 'antd';
 import { FC, useEffect, useState } from 'react';
+import {
+    countOpenLinkedPulls,
+    filterLinkedPullItems,
+    type GhSearchItem,
+} from '@/5_shared/utils/githubLinkedPulls';
 
 type Props = {
     fullName: string;
     issueNumber: number;
 };
 
+const cacheKey = (fullName: string, issueNumber: number) =>
+    `lb-open-pr:${fullName}#${issueNumber}`;
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+function readCachedCount(key: string): number | null {
+    try {
+        const raw = sessionStorage.getItem(key);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw) as { n: number; t: number };
+        if (Date.now() - parsed.t > CACHE_TTL_MS) return null;
+        return typeof parsed.n === 'number' ? parsed.n : null;
+    } catch {
+        return null;
+    }
+}
+
+function writeCachedCount(key: string, n: number) {
+    try {
+        sessionStorage.setItem(key, JSON.stringify({ n, t: Date.now() }));
+    } catch {
+        // ignore quota / private mode
+    }
+}
+
 /**
- * Lightweight client badge: shows open PR count for a GitHub issue (issue #76).
+ * Lightweight client badge: open PR count for a bounty issue (#76).
+ * Session-cached to limit unauthenticated GitHub search traffic.
  */
 const OpenPrBadge: FC<Props> = ({ fullName, issueNumber }) => {
     const [count, setCount] = useState<number | null>(null);
 
     useEffect(() => {
         let cancelled = false;
+        const key = cacheKey(fullName, issueNumber);
+        const cached = readCachedCount(key);
+        if (cached !== null) {
+            setCount(cached);
+            return;
+        }
+
         const q = encodeURIComponent(
             `repo:${fullName} is:pr is:open ${issueNumber} in:title,body`,
         );
-        fetch(`https://api.github.com/search/issues?q=${q}&per_page=5`, {
+        fetch(`https://api.github.com/search/issues?q=${q}&per_page=10`, {
+            // Browser sets User-Agent; Accept is enough for public search.
             headers: { Accept: 'application/vnd.github+json' },
         })
             .then((r) => (r.ok ? r.json() : null))
             .then((data) => {
                 if (cancelled || !data) return;
-                const n = Array.isArray(data.items) ? data.items.length : 0;
+                const items = Array.isArray(data.items)
+                    ? (data.items as GhSearchItem[])
+                    : [];
+                const n = countOpenLinkedPulls(
+                    filterLinkedPullItems(items, issueNumber),
+                );
+                writeCachedCount(key, n);
                 setCount(n);
             })
             .catch(() => {

--- a/src/4_entities/feed/ui/FeedCard/OpenPrBadge.tsx
+++ b/src/4_entities/feed/ui/FeedCard/OpenPrBadge.tsx
@@ -1,7 +1,8 @@
 'use client';
 import { Tag } from 'antd';
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 import {
+    buildLinkedPullsSearchQuery,
     countOpenLinkedPulls,
     filterLinkedPullItems,
     type GhSearchItem,
@@ -16,6 +17,9 @@ const cacheKey = (fullName: string, issueNumber: number) =>
     `lb-open-pr:${fullName}#${issueNumber}`;
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** Dedupe concurrent fetches for the same issue within one tab session. */
+const inflight = new Map<string, Promise<number>>();
 
 function readCachedCount(key: string): number | null {
     try {
@@ -37,14 +41,80 @@ function writeCachedCount(key: string, n: number) {
     }
 }
 
+async function fetchOpenPrCount(
+    fullName: string,
+    issueNumber: number,
+): Promise<number> {
+    const key = cacheKey(fullName, issueNumber);
+    const cached = readCachedCount(key);
+    if (cached !== null) return cached;
+
+    const existing = inflight.get(key);
+    if (existing) return existing;
+
+    const q = encodeURIComponent(
+        buildLinkedPullsSearchQuery(fullName, issueNumber, true),
+    );
+
+    const promise = fetch(
+        `https://api.github.com/search/issues?q=${q}&per_page=10`,
+        {
+            headers: { Accept: 'application/vnd.github+json' },
+        },
+    )
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => {
+            if (!data) return 0;
+            const items = Array.isArray(data.items)
+                ? (data.items as GhSearchItem[])
+                : [];
+            const n = countOpenLinkedPulls(
+                filterLinkedPullItems(items, issueNumber),
+            );
+            writeCachedCount(key, n);
+            return n;
+        })
+        .catch(() => 0)
+        .finally(() => {
+            inflight.delete(key);
+        });
+
+    inflight.set(key, promise);
+    return promise;
+}
+
 /**
  * Lightweight client badge: open PR count for a bounty issue (#76).
- * Session-cached to limit unauthenticated GitHub search traffic.
+ * Fetches only when in view; session-cached + inflight-deduped to limit
+ * unauthenticated GitHub search traffic on the feed.
  */
 const OpenPrBadge: FC<Props> = ({ fullName, issueNumber }) => {
+    const hostRef = useRef<HTMLSpanElement>(null);
+    const [visible, setVisible] = useState(false);
     const [count, setCount] = useState<number | null>(null);
 
     useEffect(() => {
+        const el = hostRef.current;
+        if (!el || typeof IntersectionObserver === 'undefined') {
+            setVisible(true);
+            return;
+        }
+        const io = new IntersectionObserver(
+            (entries) => {
+                if (entries.some((e) => e.isIntersecting)) {
+                    setVisible(true);
+                    io.disconnect();
+                }
+            },
+            { rootMargin: '120px' },
+        );
+        io.observe(el);
+        return () => io.disconnect();
+    }, []);
+
+    useEffect(() => {
+        if (!visible || !fullName || !issueNumber) return;
+
         let cancelled = false;
         const key = cacheKey(fullName, issueNumber);
         const cached = readCachedCount(key);
@@ -53,38 +123,23 @@ const OpenPrBadge: FC<Props> = ({ fullName, issueNumber }) => {
             return;
         }
 
-        const q = encodeURIComponent(
-            `repo:${fullName} is:pr is:open ${issueNumber} in:title,body`,
-        );
-        fetch(`https://api.github.com/search/issues?q=${q}&per_page=10`, {
-            // Browser sets User-Agent; Accept is enough for public search.
-            headers: { Accept: 'application/vnd.github+json' },
-        })
-            .then((r) => (r.ok ? r.json() : null))
-            .then((data) => {
-                if (cancelled || !data) return;
-                const items = Array.isArray(data.items)
-                    ? (data.items as GhSearchItem[])
-                    : [];
-                const n = countOpenLinkedPulls(
-                    filterLinkedPullItems(items, issueNumber),
-                );
-                writeCachedCount(key, n);
-                setCount(n);
-            })
-            .catch(() => {
-                if (!cancelled) setCount(null);
-            });
+        fetchOpenPrCount(fullName, issueNumber).then((n) => {
+            if (!cancelled) setCount(n);
+        });
+
         return () => {
             cancelled = true;
         };
-    }, [fullName, issueNumber]);
+    }, [visible, fullName, issueNumber]);
 
-    if (!count) return null;
     return (
-        <Tag color="blue" style={{ marginLeft: 8 }}>
-            {count} open PR{count === 1 ? '' : 's'}
-        </Tag>
+        <span ref={hostRef}>
+            {count ? (
+                <Tag color="blue" style={{ marginLeft: 8 }}>
+                    {count} open PR{count === 1 ? '' : 's'}
+                </Tag>
+            ) : null}
+        </span>
     );
 };
 

--- a/src/5_shared/utils/githubLinkedPulls.spec.ts
+++ b/src/5_shared/utils/githubLinkedPulls.spec.ts
@@ -1,39 +1,77 @@
 /**
- * Pure unit tests for filterLinkedPullItems (shipped module).
+ * Pure unit tests for linked-PR helpers (shipped module).
  * Run: npx tsx --test src/5_shared/utils/githubLinkedPulls.spec.ts
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+    buildLinkedPullsSearchQuery,
     countOpenLinkedPulls,
     filterLinkedPullItems,
+    referencesIssueNumber,
     type GhSearchItem,
+    type LinkedPullRequest,
 } from './githubLinkedPulls';
+
+const pr = (
+    partial: Partial<GhSearchItem> & Pick<GhSearchItem, 'number' | 'html_url'>,
+): GhSearchItem => ({
+    title: '',
+    state: 'open',
+    pull_request: { url: 'x' },
+    ...partial,
+});
+
+describe('referencesIssueNumber', () => {
+    it('matches #N with word boundaries', () => {
+        assert.equal(referencesIssueNumber('closes #10', 10), true);
+        assert.equal(referencesIssueNumber('fix(#10)', 10), true);
+        assert.equal(referencesIssueNumber('#10 is done', 10), true);
+        assert.equal(referencesIssueNumber('see issue #10.', 10), true);
+    });
+
+    it('rejects longer numbers and non-hash forms', () => {
+        assert.equal(referencesIssueNumber('closes #100', 10), false);
+        assert.equal(referencesIssueNumber('issue 10', 10), false);
+        assert.equal(referencesIssueNumber('GH-10', 10), false);
+        assert.equal(referencesIssueNumber('path/10', 10), false);
+        assert.equal(referencesIssueNumber('', 10), false);
+        assert.equal(referencesIssueNumber(null, 10), false);
+        assert.equal(referencesIssueNumber('#10', 0), false);
+    });
+});
+
+describe('buildLinkedPullsSearchQuery', () => {
+    it('scopes repo, PR type, and quoted issue ref', () => {
+        assert.equal(
+            buildLinkedPullsSearchQuery('acme/app', 76, false),
+            'repo:acme/app is:pr "#76" in:title,body',
+        );
+        assert.equal(
+            buildLinkedPullsSearchQuery('acme/app', 76, true),
+            'repo:acme/app is:pr is:open "#76" in:title,body',
+        );
+    });
+});
 
 describe('filterLinkedPullItems', () => {
     it('maps open PRs and sorts open before closed', () => {
         const items: GhSearchItem[] = [
-            {
+            pr({
                 number: 1,
-                title: 'fix stuff',
+                title: 'fix stuff #10',
                 html_url: 'https://github.com/o/r/pull/1',
                 state: 'closed',
-                pull_request: {
-                    url: 'https://api.github.com/repos/o/r/pulls/1',
-                },
                 user: { login: 'alice' },
-            },
-            {
+            }),
+            pr({
                 number: 2,
                 title: 'feat: closes #10',
                 html_url: 'https://github.com/o/r/pull/2',
                 state: 'open',
                 draft: true,
-                pull_request: {
-                    url: 'https://api.github.com/repos/o/r/pulls/2',
-                },
                 user: { login: 'bob' },
-            },
+            }),
         ];
         const result = filterLinkedPullItems(items, 10);
         assert.equal(result.length, 2);
@@ -49,7 +87,7 @@ describe('filterLinkedPullItems', () => {
         const items: GhSearchItem[] = [
             {
                 number: 3,
-                title: 'not a pr',
+                title: 'not a pr #3',
                 html_url: 'https://github.com/o/r/issues/3',
                 state: 'open',
                 user: { login: 'x' },
@@ -62,7 +100,7 @@ describe('filterLinkedPullItems', () => {
         const items: GhSearchItem[] = [
             {
                 number: 9,
-                title: 'linked',
+                title: 'linked #1',
                 html_url: 'https://github.com/o/r/pull/9',
                 state: 'open',
                 user: { login: 'c' },
@@ -75,20 +113,16 @@ describe('filterLinkedPullItems', () => {
 
     it('sorts same-state by higher number first', () => {
         const items: GhSearchItem[] = [
-            {
+            pr({
                 number: 4,
-                title: 'a',
+                title: 'a #1',
                 html_url: 'https://github.com/o/r/pull/4',
-                state: 'open',
-                pull_request: { url: 'x' },
-            },
-            {
+            }),
+            pr({
                 number: 7,
-                title: 'b',
+                title: 'b #1',
                 html_url: 'https://github.com/o/r/pull/7',
-                state: 'open',
-                pull_request: { url: 'x' },
-            },
+            }),
         ];
         const result = filterLinkedPullItems(items, 1);
         assert.deepEqual(
@@ -99,15 +133,65 @@ describe('filterLinkedPullItems', () => {
 
     it('defaults missing user login to unknown', () => {
         const items: GhSearchItem[] = [
-            {
+            pr({
                 number: 5,
-                title: 'solo',
+                title: 'solo #5',
                 html_url: 'https://github.com/o/r/pull/5',
-                state: 'open',
-                pull_request: { url: 'x' },
-            },
+            }),
         ];
         assert.equal(filterLinkedPullItems(items, 5)[0].user_login, 'unknown');
+    });
+
+    it('drops false positives that only share bare digits', () => {
+        const items: GhSearchItem[] = [
+            pr({
+                number: 99,
+                title: 'bump deps to 10.0.0',
+                body: 'no issue link here',
+                html_url: 'https://github.com/o/r/pull/99',
+            }),
+            pr({
+                number: 100,
+                title: 'closes #100',
+                html_url: 'https://github.com/o/r/pull/100',
+            }),
+        ];
+        assert.equal(filterLinkedPullItems(items, 10).length, 0);
+    });
+
+    it('keeps PRs that mention #N only in body', () => {
+        const items: GhSearchItem[] = [
+            pr({
+                number: 8,
+                title: 'docs: claim guide',
+                body: 'Closes #76\n\nMore detail.',
+                html_url: 'https://github.com/o/r/pull/8',
+            }),
+        ];
+        const result = filterLinkedPullItems(items, 76);
+        assert.equal(result.length, 1);
+        assert.equal(result[0].number, 8);
+    });
+
+    it('dedupes by PR number', () => {
+        const items: GhSearchItem[] = [
+            pr({
+                number: 3,
+                title: 'a #1',
+                html_url: 'https://github.com/o/r/pull/3',
+            }),
+            pr({
+                number: 3,
+                title: 'a #1 again',
+                html_url: 'https://github.com/o/r/pull/3',
+            }),
+        ];
+        assert.equal(filterLinkedPullItems(items, 1).length, 1);
+    });
+
+    it('returns empty for invalid issue numbers or non-arrays', () => {
+        assert.deepEqual(filterLinkedPullItems([pr({ number: 1, title: '#1', html_url: 'u' })], 0), []);
+        assert.deepEqual(filterLinkedPullItems(null as unknown as GhSearchItem[], 1), []);
     });
 });
 
@@ -115,23 +199,26 @@ describe('countOpenLinkedPulls', () => {
     it('counts only open state', () => {
         const pulls = filterLinkedPullItems(
             [
-                {
+                pr({
                     number: 1,
-                    title: 'a',
+                    title: 'a #1',
                     html_url: 'https://github.com/o/r/pull/1',
                     state: 'closed',
-                    pull_request: { url: 'x' },
-                },
-                {
+                }),
+                pr({
                     number: 2,
-                    title: 'b',
+                    title: 'b #1',
                     html_url: 'https://github.com/o/r/pull/2',
                     state: 'open',
-                    pull_request: { url: 'x' },
-                },
+                }),
             ],
             1,
         );
         assert.equal(countOpenLinkedPulls(pulls), 1);
+    });
+
+    it('returns 0 for empty or invalid input', () => {
+        assert.equal(countOpenLinkedPulls([]), 0);
+        assert.equal(countOpenLinkedPulls(null as unknown as LinkedPullRequest[]), 0);
     });
 });

--- a/src/5_shared/utils/githubLinkedPulls.spec.ts
+++ b/src/5_shared/utils/githubLinkedPulls.spec.ts
@@ -1,0 +1,45 @@
+import { filterLinkedPullItems } from './githubLinkedPulls';
+
+describe('filterLinkedPullItems', () => {
+    it('maps open PRs and sorts open before closed', () => {
+        const items = [
+            {
+                number: 1,
+                title: 'fix stuff',
+                html_url: 'https://github.com/o/r/pull/1',
+                state: 'closed',
+                pull_request: { url: 'https://api.github.com/repos/o/r/pulls/1' },
+                user: { login: 'alice' },
+            },
+            {
+                number: 2,
+                title: 'feat: closes #10',
+                html_url: 'https://github.com/o/r/pull/2',
+                state: 'open',
+                draft: true,
+                pull_request: { url: 'https://api.github.com/repos/o/r/pulls/2' },
+                user: { login: 'bob' },
+            },
+        ];
+        const result = filterLinkedPullItems(items, 10);
+        expect(result).toHaveLength(2);
+        expect(result[0].number).toBe(2);
+        expect(result[0].state).toBe('open');
+        expect(result[0].draft).toBe(true);
+        expect(result[0].user_login).toBe('bob');
+        expect(result[1].state).toBe('closed');
+    });
+
+    it('skips non-PR issues', () => {
+        const items = [
+            {
+                number: 3,
+                title: 'not a pr',
+                html_url: 'https://github.com/o/r/issues/3',
+                state: 'open',
+                user: { login: 'x' },
+            },
+        ];
+        expect(filterLinkedPullItems(items, 3)).toHaveLength(0);
+    });
+});

--- a/src/5_shared/utils/githubLinkedPulls.spec.ts
+++ b/src/5_shared/utils/githubLinkedPulls.spec.ts
@@ -1,14 +1,26 @@
-import { filterLinkedPullItems } from './githubLinkedPulls';
+/**
+ * Pure unit tests for filterLinkedPullItems (shipped module).
+ * Run: npx tsx --test src/5_shared/utils/githubLinkedPulls.spec.ts
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    countOpenLinkedPulls,
+    filterLinkedPullItems,
+    type GhSearchItem,
+} from './githubLinkedPulls';
 
 describe('filterLinkedPullItems', () => {
     it('maps open PRs and sorts open before closed', () => {
-        const items = [
+        const items: GhSearchItem[] = [
             {
                 number: 1,
                 title: 'fix stuff',
                 html_url: 'https://github.com/o/r/pull/1',
                 state: 'closed',
-                pull_request: { url: 'https://api.github.com/repos/o/r/pulls/1' },
+                pull_request: {
+                    url: 'https://api.github.com/repos/o/r/pulls/1',
+                },
                 user: { login: 'alice' },
             },
             {
@@ -17,21 +29,24 @@ describe('filterLinkedPullItems', () => {
                 html_url: 'https://github.com/o/r/pull/2',
                 state: 'open',
                 draft: true,
-                pull_request: { url: 'https://api.github.com/repos/o/r/pulls/2' },
+                pull_request: {
+                    url: 'https://api.github.com/repos/o/r/pulls/2',
+                },
                 user: { login: 'bob' },
             },
         ];
         const result = filterLinkedPullItems(items, 10);
-        expect(result).toHaveLength(2);
-        expect(result[0].number).toBe(2);
-        expect(result[0].state).toBe('open');
-        expect(result[0].draft).toBe(true);
-        expect(result[0].user_login).toBe('bob');
-        expect(result[1].state).toBe('closed');
+        assert.equal(result.length, 2);
+        assert.equal(result[0].number, 2);
+        assert.equal(result[0].state, 'open');
+        assert.equal(result[0].draft, true);
+        assert.equal(result[0].user_login, 'bob');
+        assert.equal(result[1].state, 'closed');
+        assert.equal(result[1].user_login, 'alice');
     });
 
     it('skips non-PR issues', () => {
-        const items = [
+        const items: GhSearchItem[] = [
             {
                 number: 3,
                 title: 'not a pr',
@@ -40,6 +55,83 @@ describe('filterLinkedPullItems', () => {
                 user: { login: 'x' },
             },
         ];
-        expect(filterLinkedPullItems(items, 3)).toHaveLength(0);
+        assert.equal(filterLinkedPullItems(items, 3).length, 0);
+    });
+
+    it('accepts PRs identified by /pull/ URL without pull_request field', () => {
+        const items: GhSearchItem[] = [
+            {
+                number: 9,
+                title: 'linked',
+                html_url: 'https://github.com/o/r/pull/9',
+                state: 'open',
+                user: { login: 'c' },
+            },
+        ];
+        const result = filterLinkedPullItems(items, 1);
+        assert.equal(result.length, 1);
+        assert.equal(result[0].number, 9);
+    });
+
+    it('sorts same-state by higher number first', () => {
+        const items: GhSearchItem[] = [
+            {
+                number: 4,
+                title: 'a',
+                html_url: 'https://github.com/o/r/pull/4',
+                state: 'open',
+                pull_request: { url: 'x' },
+            },
+            {
+                number: 7,
+                title: 'b',
+                html_url: 'https://github.com/o/r/pull/7',
+                state: 'open',
+                pull_request: { url: 'x' },
+            },
+        ];
+        const result = filterLinkedPullItems(items, 1);
+        assert.deepEqual(
+            result.map((p) => p.number),
+            [7, 4],
+        );
+    });
+
+    it('defaults missing user login to unknown', () => {
+        const items: GhSearchItem[] = [
+            {
+                number: 5,
+                title: 'solo',
+                html_url: 'https://github.com/o/r/pull/5',
+                state: 'open',
+                pull_request: { url: 'x' },
+            },
+        ];
+        assert.equal(filterLinkedPullItems(items, 5)[0].user_login, 'unknown');
+    });
+});
+
+describe('countOpenLinkedPulls', () => {
+    it('counts only open state', () => {
+        const pulls = filterLinkedPullItems(
+            [
+                {
+                    number: 1,
+                    title: 'a',
+                    html_url: 'https://github.com/o/r/pull/1',
+                    state: 'closed',
+                    pull_request: { url: 'x' },
+                },
+                {
+                    number: 2,
+                    title: 'b',
+                    html_url: 'https://github.com/o/r/pull/2',
+                    state: 'open',
+                    pull_request: { url: 'x' },
+                },
+            ],
+            1,
+        );
+        assert.equal(countOpenLinkedPulls(pulls), 1);
     });
 });

--- a/src/5_shared/utils/githubLinkedPulls.ts
+++ b/src/5_shared/utils/githubLinkedPulls.ts
@@ -1,0 +1,87 @@
+/**
+ * Resolve open GitHub pull requests that reference a bounty issue.
+ * Used to surface "Existing PRs" on the issue detail page (#76).
+ */
+
+export type LinkedPullRequest = {
+    number: number;
+    title: string;
+    html_url: string;
+    state: 'open' | 'closed';
+    draft: boolean;
+    user_login: string;
+};
+
+type GhSearchItem = {
+    number: number;
+    title: string;
+    html_url: string;
+    state: string;
+    draft?: boolean;
+    pull_request?: { url: string };
+    user?: { login?: string };
+};
+
+/**
+ * Pure filter: keep only pull-request search hits that look related to the issue.
+ */
+export function filterLinkedPullItems(
+    items: GhSearchItem[],
+    issueNumber: number,
+): LinkedPullRequest[] {
+    const needle = String(issueNumber);
+    const out: LinkedPullRequest[] = [];
+    for (const item of items) {
+        if (!item.pull_request && !item.html_url?.includes('/pull/')) continue;
+        const title = item.title ?? '';
+        const url = item.html_url ?? '';
+        // Prefer explicit issue references in title; still allow search hits
+        const related =
+            title.includes(`#${needle}`) ||
+            title.includes(needle) ||
+            true; /* search already scoped */
+        if (!related) continue;
+        out.push({
+            number: item.number,
+            title: item.title,
+            html_url: item.html_url,
+            state: item.state === 'closed' ? 'closed' : 'open',
+            draft: Boolean(item.draft),
+            user_login: item.user?.login ?? 'unknown',
+        });
+    }
+    // open first
+    out.sort((a, b) => {
+        if (a.state !== b.state) return a.state === 'open' ? -1 : 1;
+        return b.number - a.number;
+    });
+    return out;
+}
+
+export async function fetchLinkedPullRequests(
+    fullName: string,
+    issueNumber: number,
+): Promise<LinkedPullRequest[]> {
+    if (!fullName || !issueNumber) return [];
+    const q = encodeURIComponent(
+        `repo:${fullName} is:pr ${issueNumber} in:title,body`,
+    );
+    try {
+        const res = await fetch(
+            `https://api.github.com/search/issues?q=${q}&per_page=10`,
+            {
+                headers: {
+                    Accept: 'application/vnd.github+json',
+                    'User-Agent': 'Lightning-Bounties-lb-next',
+                },
+                // Cache for 5 minutes on Next.js server
+                next: { revalidate: 300 },
+            } as RequestInit,
+        );
+        if (!res.ok) return [];
+        const data = (await res.json()) as { items?: GhSearchItem[] };
+        return filterLinkedPullItems(data.items ?? [], issueNumber);
+    } catch {
+        return [];
+    }
+}

--- a/src/5_shared/utils/githubLinkedPulls.ts
+++ b/src/5_shared/utils/githubLinkedPulls.ts
@@ -1,5 +1,5 @@
 /**
- * Resolve open GitHub pull requests that reference a bounty issue.
+ * Resolve GitHub pull requests that reference a bounty issue.
  * Used to surface "Existing PRs" on the issue detail page (#76).
  */
 
@@ -12,7 +12,7 @@ export type LinkedPullRequest = {
     user_login: string;
 };
 
-type GhSearchItem = {
+export type GhSearchItem = {
     number: number;
     title: string;
     html_url: string;
@@ -23,39 +23,34 @@ type GhSearchItem = {
 };
 
 /**
- * Pure filter: keep only pull-request search hits that look related to the issue.
+ * Pure map/sort: keep PR search hits, open first, then highest number.
+ * Search query is already scoped to the repo + issue number.
  */
 export function filterLinkedPullItems(
     items: GhSearchItem[],
-    issueNumber: number,
+    _issueNumber: number,
 ): LinkedPullRequest[] {
-    const needle = String(issueNumber);
     const out: LinkedPullRequest[] = [];
     for (const item of items) {
         if (!item.pull_request && !item.html_url?.includes('/pull/')) continue;
-        const title = item.title ?? '';
-        const url = item.html_url ?? '';
-        // Prefer explicit issue references in title; still allow search hits
-        const related =
-            title.includes(`#${needle}`) ||
-            title.includes(needle) ||
-            true; /* search already scoped */
-        if (!related) continue;
         out.push({
             number: item.number,
-            title: item.title,
-            html_url: item.html_url,
+            title: item.title ?? '',
+            html_url: item.html_url ?? '',
             state: item.state === 'closed' ? 'closed' : 'open',
             draft: Boolean(item.draft),
             user_login: item.user?.login ?? 'unknown',
         });
     }
-    // open first
     out.sort((a, b) => {
         if (a.state !== b.state) return a.state === 'open' ? -1 : 1;
         return b.number - a.number;
     });
     return out;
+}
+
+export function countOpenLinkedPulls(pulls: LinkedPullRequest[]): number {
+    return pulls.filter((p) => p.state === 'open').length;
 }
 
 export async function fetchLinkedPullRequests(

--- a/src/5_shared/utils/githubLinkedPulls.ts
+++ b/src/5_shared/utils/githubLinkedPulls.ts
@@ -17,31 +17,87 @@ export type GhSearchItem = {
     title: string;
     html_url: string;
     state: string;
+    body?: string | null;
     draft?: boolean;
     pull_request?: { url: string };
     user?: { login?: string };
 };
 
+/** owner/repo with no spaces or extra path segments */
+const REPO_FULL_NAME = /^[^/\s]+\/[^/\s]+$/;
+
 /**
- * Pure map/sort: keep PR search hits, open first, then highest number.
- * Search query is already scoped to the repo + issue number.
+ * True when text mentions this issue as #N (not #N0 / GH-N / path/N).
+ * Matches common closing forms: close #12, fixes #12, (#12), " #12 ".
+ */
+export function referencesIssueNumber(
+    text: string | null | undefined,
+    issueNumber: number,
+): boolean {
+    if (!text || !issueNumber || issueNumber < 1) return false;
+    const re = new RegExp(`(?:^|[^A-Za-z0-9_/])#${issueNumber}(?!\\d)`);
+    return re.test(text);
+}
+
+/**
+ * Build GitHub issue-search query for PRs that mention #issueNumber.
+ * openOnly=true limits to open PRs (feed badge).
+ */
+export function buildLinkedPullsSearchQuery(
+    fullName: string,
+    issueNumber: number,
+    openOnly = false,
+): string {
+    const open = openOnly ? ' is:open' : '';
+    // Quote #N so search prefers the issue reference token over bare digits.
+    return `repo:${fullName} is:pr${open} "#${issueNumber}" in:title,body`;
+}
+
+function isPullSearchItem(item: GhSearchItem): boolean {
+    return Boolean(item.pull_request) || Boolean(item.html_url?.includes('/pull/'));
+}
+
+/**
+ * Pure map/filter/sort: keep PR search hits that reference #issueNumber,
+ * dedupe by number, open first, then highest number.
  */
 export function filterLinkedPullItems(
     items: GhSearchItem[],
-    _issueNumber: number,
+    issueNumber: number,
 ): LinkedPullRequest[] {
+    if (!issueNumber || issueNumber < 1 || !Array.isArray(items)) return [];
+
+    const seen = new Set<number>();
     const out: LinkedPullRequest[] = [];
+
     for (const item of items) {
-        if (!item.pull_request && !item.html_url?.includes('/pull/')) continue;
+        if (!isPullSearchItem(item)) continue;
+        if (typeof item.number !== 'number' || seen.has(item.number)) continue;
+
+        const title = item.title ?? '';
+        const body = item.body ?? '';
+        // Require an explicit #N mention when we have text; if both empty,
+        // keep the hit (search already scoped) so we do not drop sparse payloads.
+        const hasText = Boolean(title.trim() || body.trim());
+        if (
+            hasText &&
+            !referencesIssueNumber(title, issueNumber) &&
+            !referencesIssueNumber(body, issueNumber)
+        ) {
+            continue;
+        }
+
+        seen.add(item.number);
         out.push({
             number: item.number,
-            title: item.title ?? '',
+            title,
             html_url: item.html_url ?? '',
             state: item.state === 'closed' ? 'closed' : 'open',
             draft: Boolean(item.draft),
             user_login: item.user?.login ?? 'unknown',
         });
     }
+
     out.sort((a, b) => {
         if (a.state !== b.state) return a.state === 'open' ? -1 : 1;
         return b.number - a.number;
@@ -50,6 +106,7 @@ export function filterLinkedPullItems(
 }
 
 export function countOpenLinkedPulls(pulls: LinkedPullRequest[]): number {
+    if (!Array.isArray(pulls)) return 0;
     return pulls.filter((p) => p.state === 'open').length;
 }
 
@@ -57,10 +114,19 @@ export async function fetchLinkedPullRequests(
     fullName: string,
     issueNumber: number,
 ): Promise<LinkedPullRequest[]> {
-    if (!fullName || !issueNumber) return [];
+    if (
+        !fullName ||
+        !REPO_FULL_NAME.test(fullName) ||
+        !issueNumber ||
+        issueNumber < 1
+    ) {
+        return [];
+    }
+
     const q = encodeURIComponent(
-        `repo:${fullName} is:pr ${issueNumber} in:title,body`,
+        buildLinkedPullsSearchQuery(fullName, issueNumber, false),
     );
+
     try {
         const res = await fetch(
             `https://api.github.com/search/issues?q=${q}&per_page=10`,


### PR DESCRIPTION
## Summary

Surfaces **Existing PRs** on the Lightning Bounties issue detail page so hunters can see work already in flight and avoid duplicate effort.

Closes #76

### UX

- Badge next to the issue title: `N open PR(s)` when linked open PRs exist
- **Existing PRs** section under reward meta: state/draft tags, title links, author
- Feed cards: session-cached open-PR badge (loads only when the card is in view)

### Implementation

| Piece | Role |
|-------|------|
| `fetchLinkedPullRequests` | Server-side GitHub search (`#N` in title/body), 5m revalidate |
| `filterLinkedPullItems` / `countOpenLinkedPulls` | Pure map/filter/dedupe/sort/count |
| `referencesIssueNumber` | Drops bare-digit false positives (`10` vs `#10` vs `#100`) |
| `buildLinkedPullsSearchQuery` | Shared query for issue page + feed badge |
| `IssueExistingPulls` | Issue detail list |
| `OpenPrBadge` | Client feed badge: IntersectionObserver + sessionStorage + inflight dedupe |

Search is scoped to `repo:owner/name is:pr "#N" in:title,body`. Results must still mention `#N` in title or body when text is present.

### Tests

```bash
npx tsx --test src/5_shared/utils/githubLinkedPulls.spec.ts
```

14/14 pass (filter, count, query builder, `#N` boundary matching, dedupe, false positives).

### Test plan

- [ ] Open an LB issue that has a PR with `close #N` / `#N` in the body: title badge + Existing PRs list appear
- [ ] Issue with only closed linked PRs: list shows closed tags, no open badge
- [ ] Issue with no linked PRs: no badge, no Existing PRs block
- [ ] Feed: open-PR tag appears after card scrolls into view; reload uses session cache
- [ ] GitHub search failure / rate limit: page still renders; badge stays hidden

### Notes

- Unauthenticated GitHub search is best-effort; failures return empty lists
- Feed badge is intentionally lazy to reduce search API pressure